### PR TITLE
Revert "Reduce default volume"

### DIFF
--- a/src/config/main.lua.d/40-device-defaults.lua
+++ b/src/config/main.lua.d/40-device-defaults.lua
@@ -5,7 +5,6 @@ device_defaults.properties = {
   -- when set to false, default nodes and routes are selected based on
   -- their priorities and any runtime changes do not persist after restart
   ["use-persistent-storage"] = true,
-  ["default-volume"] = 0.03,
 
   -- the default volume to apply to ACP device nodes, in the linear scale
   --["default-volume"] = 0.4,


### PR DESCRIPTION
Reverts pop-os/wireplumber#1, due to https://reddit.com/r/pop_os/comments/uj4hc8/anyone_else_have_really_low_volume_even_at_max/

GitHub's automatic revert chose the branch name, and it was not expected to build correctly on any version but 22.04