### PR TITLE
fix: Start list of known sound cards needing ALSA headroom

### DIFF
--- a/src/config/main.lua.d/50-alsa-config.lua
+++ b/src/config/main.lua.d/50-alsa-config.lua
@@ -20,7 +20,7 @@ alsa_monitor.properties = {
 
 alsa_monitor.rules = {
   -- An array of matches/actions to evaluate.
-  -- 
+  --
   -- If you want to disable some devices or nodes, you can apply properties per device as the following example.
   -- The name can be found by running pw-cli ls Device, or pw-cli dump Device
   --{
@@ -112,6 +112,17 @@ alsa_monitor.rules = {
       --["api.alsa.disable-mmap"]  = false,
       --["api.alsa.disable-batch"] = false,
       --["session.suspend-timeout-seconds"] = 5,  -- 0 disables suspend
+    },
+  },
+  {
+    -- Devices known to require a headroom.
+    matches = {
+      {
+        { "node.name", "matches", "alsa_output.usb-0b0e_Jabra_SPEAK_410_USB_501AA523CBCAx010900-00.analog-stereo" }
+      },
+    },
+    apply_properties = {
+      ["api.alsa.headroom"] = 1024,
     },
   },
 }

--- a/src/config/main.lua.d/50-alsa-config.lua
+++ b/src/config/main.lua.d/50-alsa-config.lua
@@ -118,11 +118,29 @@ alsa_monitor.rules = {
     -- Devices known to require a headroom.
     matches = {
       {
-        { "node.name", "matches", "alsa_output.usb-0b0e_Jabra_SPEAK_410_USB_501AA523CBCAx010900-00.analog-stereo" }
+        {
+          "node.name",
+          "matches",
+          "alsa_output.usb-0b0e_Jabra_SPEAK_410_USB_501AA523CBCAx010900-00.analog-stereo"
+        },
       },
     },
     apply_properties = {
       ["api.alsa.headroom"] = 1024,
+    },
+  },
+  {
+    matches = {
+      {
+        {
+          "node.name",
+          "matches",
+          "alsa_output.usb-Schiit_Audio_Schiit_Hel-00.analog-stereo"
+        },
+      },
+    },
+    apply_properties = {
+      ["api.alsa.headroom"] = 2048,
     },
   },
 }


### PR DESCRIPTION
Changing from the default of 0 to 1024 is [commonly reported by Pipewire](https://gitlab.freedesktop.org/pipewire/pipewire/-/wikis/Troubleshooting#underrununderflow-and-broken-pipe-errors) to [fix audio crackling](https://www.reddit.com/r/pop_os/comments/ut0ju4/audio_crackling_report_sound_card_details_here/i96sscg/).