### PR TITLE
Disable suspend on idle for Digital outputs by default

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wireplumber (0.4.9-1pop1) jammy; urgency=medium
+
+  * Backport to Pop
+
+ -- Michael Aaron Murphy <mmstick@pm.me>  Wed, 06 Apr 2022 23:38:01 +0200
+
 wireplumber (0.4.9-1) unstable; urgency=medium
 
   * Team upload.

--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,7 @@ Vcs-Git: https://salsa.debian.org/utopia-team/wireplumber.git
 Rules-Requires-Root: no
 
 Package: libwireplumber-0.4-0
-Architecture: linux-any
+Architecture: i386 amd64 arm64
 Multi-Arch: same
 Depends: ${misc:Depends},
          ${shlibs:Depends},
@@ -40,7 +40,7 @@ Description: Shared libraries for WirePlumber
 
 Package: libwireplumber-0.4-dev
 Section: libdevel
-Architecture: linux-any
+Architecture: i386 amd64 arm64
 Multi-Arch: same
 Depends: ${misc:Depends},
          libwireplumber-0.4-0 (= ${binary:Version}),
@@ -54,7 +54,7 @@ Description: Development files for WirePlumber
  This package contains the development files.
 
 Package: wireplumber
-Architecture: linux-any
+Architecture: i386 amd64 arm64
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          libwireplumber-0.4-0 (= ${binary:Version}),
@@ -71,7 +71,7 @@ Description: modular session / policy manager for PipeWire
 
 Package: gir1.2-wp-0.4
 Section: introspection
-Architecture: linux-any
+Architecture: i386 amd64 arm64
 Multi-Arch: same
 Depends: ${misc:Depends},
          ${gir:Depends},

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)

--- a/src/config/main.lua.d/40-device-defaults.lua
+++ b/src/config/main.lua.d/40-device-defaults.lua
@@ -5,6 +5,7 @@ device_defaults.properties = {
   -- when set to false, default nodes and routes are selected based on
   -- their priorities and any runtime changes do not persist after restart
   ["use-persistent-storage"] = true,
+  ["default-volume"] = 0.03,
 
   -- the default volume to apply to ACP device nodes, in the linear scale
   --["default-volume"] = 0.4,

--- a/src/config/main.lua.d/40-device-defaults.lua
+++ b/src/config/main.lua.d/40-device-defaults.lua
@@ -5,7 +5,6 @@ device_defaults.properties = {
   -- when set to false, default nodes and routes are selected based on
   -- their priorities and any runtime changes do not persist after restart
   ["use-persistent-storage"] = true,
-  ["default-volume"] = 0.03,
 
   -- the default volume to apply to ACP device nodes, in the linear scale
   --["default-volume"] = 0.4,

--- a/src/config/main.lua.d/50-alsa-config.lua
+++ b/src/config/main.lua.d/50-alsa-config.lua
@@ -20,7 +20,7 @@ alsa_monitor.properties = {
 
 alsa_monitor.rules = {
   -- An array of matches/actions to evaluate.
-  -- 
+  --
   -- If you want to disable some devices or nodes, you can apply properties per device as the following example.
   -- The name can be found by running pw-cli ls Device, or pw-cli dump Device
   --{
@@ -112,6 +112,17 @@ alsa_monitor.rules = {
       --["api.alsa.disable-mmap"]  = false,
       --["api.alsa.disable-batch"] = false,
       --["session.suspend-timeout-seconds"] = 5,  -- 0 disables suspend
+    },
+  },
+  {
+    -- Devices known to require a headroom.
+    matches = {
+      {
+        { "node.name", "matches", "alsa_output.usb-0b0e_Jabra_SPEAK_410_USB_501AA523CBCAx010900-00.analog-stereo" }
+      },
+    },
+    apply_properties = {
+      ["api.alsa.headroom"] = 1024,
     },
   },
 }

--- a/src/config/main.lua.d/50-alsa-config.lua
+++ b/src/config/main.lua.d/50-alsa-config.lua
@@ -118,11 +118,29 @@ alsa_monitor.rules = {
     -- Devices known to require a headroom.
     matches = {
       {
-        { "node.name", "matches", "alsa_output.usb-0b0e_Jabra_SPEAK_410_USB_501AA523CBCAx010900-00.analog-stereo" }
+        {
+          "node.name",
+          "matches",
+          "alsa_output.usb-0b0e_Jabra_SPEAK_410_USB_501AA523CBCAx010900-00.analog-stereo"
+        },
       },
     },
     apply_properties = {
       ["api.alsa.headroom"] = 1024,
+    },
+  },
+  {
+    matches = {
+      {
+        {
+          "node.name",
+          "matches",
+          "alsa_output.usb-Schiit_Audio_Schiit_Hel-00.analog-stereo"
+        },
+      },
+    },
+    apply_properties = {
+      ["api.alsa.headroom"] = 2048,
     },
   },
 }

--- a/src/config/main.lua.d/50-alsa-config.lua
+++ b/src/config/main.lua.d/50-alsa-config.lua
@@ -143,4 +143,28 @@ alsa_monitor.rules = {
       ["api.alsa.headroom"] = 2048,
     },
   },
+  -- Matches Digital (S/PDIF) output devices
+  {
+    matches = {
+      {
+        {
+          "node.name",
+          "matches",
+          "alsa_output.*"
+        },
+        {
+          "node.description",
+          "matches",
+          "*Digital*"
+        }
+      },
+    },
+    -- Stops them from suspending on idle.
+    -- This fixes an issue where the first few seconds of audio
+    -- playback are missed while the output device (receiver,
+    -- soundbar, etc.) is starting up again.
+    apply_properties = {
+      ["session.suspend-timeout-seconds"] = 0,
+    },
+  },
 }


### PR DESCRIPTION
Fixes an annoying problem with digital outputs that I assume should be common with most digital audio devices.

When the device receives an audio signal again after suspending, it takes a couple of seconds to start up, causing the user to miss the audio that played back during that time.
E.g., https://unix.stackexchange.com/questions/676846/how-do-i-disable-audio-sink-suspend-on-idle-using-wireplumber-in-fedora-35-so-th

I'm not 100% sure if matching "Digital" in the node description is the best approach.
Although it did work for me as all my digital output nodes had that in the description, I'm not sure that would apply for all devices people might be using.
However it seemed better than simply applying the property to all audio outputs as I don't know the side effects that might cause.

Clearly I'm no expert so I'm sorry if I did anything wrong and any input is appreciated.
Thanks